### PR TITLE
FIX suit_ROI_summarize

### DIFF
--- a/suit_ROI_summarize.m
+++ b/suit_ROI_summarize.m
@@ -64,6 +64,10 @@ if (nargin<1 || isempty(images))
     images=spm_select(inf,'image','Select images to do statistics on');
 end;
 
+if endsWith(atlas, ',1')
+    atlas = atlas(1:end-2); 
+end;
+
 if (~isstruct(atlas))
     if (~exist(atlas,'file'))
         error(sprintf('Atlas file: %s not found. \nYou may have to download github/DiedrichsenLab/cerebellar_atlases, \n or set the location of the atlas directory in suit_defaults.m',atlas));


### PR DESCRIPTION
At the ROI analysis with atlas step, when mannually specifing Atlas image, the variable atlas ends with ',1' after the file path. This results in an error report of atlas not found. 
<img width="383" alt="Screenshot 2024-07-03 201944" src="https://github.com/jdiedrichsen/suit/assets/712044/a58e2472-c963-4a30-b03c-37826b881da3">

